### PR TITLE
tweaked (===) to give more information on errors (bumped major version)

### DIFF
--- a/Math/MFSolve.hs
+++ b/Math/MFSolve.hs
@@ -730,11 +730,13 @@ addEquality0 lhs rhs whatever diff =
       Left (InconsistentEq c Nothing) -> Left (InconsistentEq c (Just (lhs, rhs)))
       answer -> answer
 
+
 addEq0 :: (Hashable v, Hashable n, RealFrac (Phase n), Ord v, Floating n) => Dependencies v n -> Expr v n -> Either (DepError v n) (Dependencies v n)
 -- adding a constant equation
 addEq0 _  (ConstE c) =
-  Left $ if c == 0 then RedundantEq Nothing
+  Left $ if abs c < epsilon then RedundantEq Nothing
          else InconsistentEq c Nothing
+  where epsilon = 0.0001
 
 -- adding a linear equation
 addEq0 (Dependencies vdep lin trig trig2 nonlin) (Expr lt [] []) =

--- a/mfsolve.cabal
+++ b/mfsolve.cabal
@@ -1,5 +1,5 @@
 Name:		mfsolve
-Version: 	0.3.1.0
+Version: 	1.0.0.0
 Synopsis:	Equation solver and calculator à la metafont
 Category: 	Math
 Copyright: 	Kristof Bastiaensen (2015)

--- a/mfsolve.cabal
+++ b/mfsolve.cabal
@@ -1,5 +1,5 @@
 Name:		mfsolve
-Version: 	1.0.0.0
+Version: 	0.4.0.1
 Synopsis:	Equation solver and calculator à la metafont
 Category: 	Math
 Copyright: 	Kristof Bastiaensen (2015)


### PR DESCRIPTION
the API change is to the exception type

the code is absolutely terrible, but I needed the info

You probably don't want to pull this code, but rather do something better.

For example, the "redundant" and "inconsistent" exceptions should _always_ offer to show the offending equation.   I just hacked things to do minimal violence to the code.
