### PR TITLE
mtl-2.3 compatibility

### DIFF
--- a/Math/MFSolve.hs
+++ b/Math/MFSolve.hs
@@ -102,6 +102,7 @@ where
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as H
 import GHC.Generics
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Reader


### PR DESCRIPTION
mtl-2.3.1 dropped the reexport of `Control.Monad`, so `import Control.Monad`